### PR TITLE
Small tidy up for FullPage helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ $cacheDirectory = __DIR__ . '../cache';
 $adapter = new Zoop\Juggernaut\Adapter\FileSystem($cacheDirectory);
 
 $pageCache = new Zoop\Juggernaut\Helper\FullPage($adapter, $pageTtl);
+$pageCache->start();
 ```
 You can use any of the provided adapters to store the full page cache. eg.
 ```php
@@ -113,7 +114,7 @@ $password='mymongopass';
 $adapter = new Zoop\Juggernaut\Adapter\MongoDB($database, $username, $password);
 
 $pageCache = new Zoop\Juggernaut\Helper\FullPage($adapter, $pageTtl);
-
+$pageCache->start();
 ```
 There's no need to manually save the rendered page to cache as the script will automatically flush the page output to the cache adapter once the script exits.
 #### Database

--- a/src/Zoop/Juggernaut/Helper/FullPage.php
+++ b/src/Zoop/Juggernaut/Helper/FullPage.php
@@ -23,7 +23,7 @@ class FullPage {
 
     public function setAuto($auto)
     {
-        $this->auto = $auto;
+        $this->auto = (boolean) $auto;
     }
 
     public function getCompress()
@@ -33,7 +33,7 @@ class FullPage {
 
     public function setCompress($compress)
     {
-        $this->compress = $compress;
+        $this->compress = (boolean) $compress;
     }
 
     public function getAdapter()
@@ -41,7 +41,7 @@ class FullPage {
         return $this->adapter;
     }
 
-    public function setAdapter($adapter)
+    public function setAdapter(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
     }

--- a/src/Zoop/Juggernaut/Helper/FullPage.php
+++ b/src/Zoop/Juggernaut/Helper/FullPage.php
@@ -16,7 +16,38 @@ class FullPage {
     private $auto = true;
     private $compress = true;
 
-    public function __construct(AdapterInterface $adapter = null, $ttl = 300, $auto = true) {
+    public function getAuto()
+    {
+        return $this->auto;
+    }
+
+    public function setAuto($auto)
+    {
+        $this->auto = $auto;
+    }
+
+    public function getCompress()
+    {
+        return $this->compress;
+    }
+
+    public function setCompress($compress)
+    {
+        $this->compress = $compress;
+    }
+
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    public function setAdapter($adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    public function __construct(AdapterInterface $adapter = null, $ttl = 300, $auto = true, $compress = true)
+    {
         if (is_null($adapter)) {
             $this->adapter = new FileSystem();
         } else {
@@ -25,17 +56,21 @@ class FullPage {
         $this->adapter->setTtl($ttl);
 
         $this->auto = $auto;
-
-        if ($this->auto === true) {
-            $this->start();
-        }
+        $this->compress = $compress;
     }
 
-    public function setTtl($ttl) {
+    public function setTtl($ttl)
+    {
         $this->adapter->setTtl($ttl);
     }
 
-    public function start() {
+    public function start()
+    {
+        //Full page cache should only be used for a GET request
+        if ($_SERVER['REQUEST_METHOD'] != 'GET') {
+            throw new \Exception('Juggeranut full page cache helper should only be used for GET requests');
+        }
+
         $key = $this->getFileName();
         $cache = $this->adapter->getItem($key, $success);
 
@@ -50,7 +85,8 @@ class FullPage {
         }
     }
 
-    public function end() {
+    public function end()
+    {
         $html = ob_get_contents();
         if ($this->compress) {
             //remove new lines
@@ -62,12 +98,14 @@ class FullPage {
         ob_end_flush();
     }
 
-    public function setHandler(AdapterInterface $adapter) {
+    public function setHandler(AdapterInterface $adapter)
+    {
         $this->adapter = $adapter;
         return $this;
     }
 
-    private function getFileName() {
+    private function getFileName()
+    {
         if ((isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) {
             $protocol = 'https://';
         } else {
@@ -76,5 +114,4 @@ class FullPage {
         $fileName = $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
         return $fileName;
     }
-
 }


### PR DESCRIPTION
@crimsonronin please give a solid review. Changes are:
- start method must now be used explicitly. Auto start inside the constructor just didn't feel right.
- getters and setters added
- throw exception if the request is not a GET - forces consumers to test for for GET before creating an adapter instance.
- Add the `compress` argument to the constructor
